### PR TITLE
updates maintainers

### DIFF
--- a/fetch_demos/package.xml
+++ b/fetch_demos/package.xml
@@ -4,7 +4,11 @@
   <name>fetch_demos</name>
   <version>0.0.0</version>
   <description>Fetch Demos: demonstrations which run on Fetch robots, on Hardware and in Gazebo</description>
-  <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
+  <maintainer email="selliott@fetchrobotics.com">Sarah Elliott</maintainer>
+  <maintainer email="narora@fetchrobotics.com">Niharika Arora</maintainer>
+  <maintainer email="csaldanha@fetchrobotics.com">Carl Saldanha</maintainer>
+  <maintainer email="erelson@fetchrobotics.com">Eric Relson</maintainer>
+  <maintainer email="opensource@fetchrobotics.com">Fetch Robotics Open Source Team</maintainer>
 
   <license>BSD</license>
   <url type="website">https://docs.fetchrobotics.com</url>
@@ -12,7 +16,7 @@
   <url type="bugtracker">https://github.com/fetchrobotics/fetch_demos/issues</url>
   <url type="wiki">https://wiki.ros.org/fetch_demos</url>
 
-  <author email="amoriarty@fetchrobotics.com">Alex Moriarty</author>
+  <author>Alex Moriarty</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/fetch_demos_common/package.xml
+++ b/fetch_demos_common/package.xml
@@ -6,10 +6,12 @@
   <description>
     common code shared by for fetch_demos.
   </description>
-  <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
   <maintainer email="narora@fetchrobotics.com">Niharika Arora</maintainer>
   <maintainer email="selliott@fetchrobotics.com">Sarah Elliott</maintainer>
-  <maintainer email="ijwo@fetchrobotics.com">I-Chen Jwo</maintainer>
+  <maintainer email="csaldanha@fetchrobotics.com">Carl Saldanha</maintainer>
+  <maintainer email="erelson@fetchrobotics.com">Eric Relson</maintainer>
+  <maintainer email="opensource@fetchrobotics.com">Fetch Robotics Open Source Team</maintainer>
+  <author>I-Chen Jwo</maintainer>
   <license>BSD</license>
   <url>http://ros.org/wiki/fetch_demos_common</url>
 

--- a/fetch_grasp_cube_demo/package.xml
+++ b/fetch_grasp_cube_demo/package.xml
@@ -6,10 +6,12 @@
   <description>
     A demonstration where the Fetch grasps coloured cubes from a table, and places them into matching bins.
   </description>
-  <author></author>
-  <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
-  <maintainer email="narora@fetchrobotics.com">Niharika Arora</maintainer>
+  <author>I-Chen Jwo</author>
   <maintainer email="selliott@fetchrobotics.com">Sarah Elliott</maintainer>
+  <maintainer email="narora@fetchrobotics.com">Niharika Arora</maintainer>
+  <maintainer email="csaldanha@fetchrobotics.com">Carl Saldanha</maintainer>
+  <maintainer email="erelson@fetchrobotics.com">Eric Relson</maintainer>
+  <maintainer email="opensource@fetchrobotics.com">Fetch Robotics Open Source Team</maintainer>
   <license>BSD</license>
   <url>http://ros.org/wiki/fetch_grasp_cube_demo</url>
   <buildtool_depend>catkin</buildtool_depend>


### PR DESCRIPTION
Listed multiple individual maintainers and also included the internal
mailing list to ensure the load is distributed in the event of build
failures.